### PR TITLE
versioning setuptools

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,46 @@
+name: Upload Python Package
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v0.0.x,
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Changes in this Release
+          draft: false
+          prerelease: false
+  deploy:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,5 +1,8 @@
 name: Upload Python Package
 
+# taken from https://github.com/xarray-contrib/xskillscore/blob/main/.github/workflows/python-publish.yml
+# see guide https://github.com/xarray-contrib/xskillscore/blob/main/HOWTORELEASE.rst
+
 on:
   push:
     tags:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.0.1
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:xbitinfo/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,11 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/observingClouds/xbitinfo",
-    version="0.0.1",
     zip_safe=False,
+    use_scm_version={"version_scheme": "post-release", "local_scheme": "dirty-tag"},
+    setup_requires=[
+        "setuptools_scm",
+        "setuptools>=30.3.0",
+        "setuptools_scm_git_archive",
+    ],
 )

--- a/xbitinfo/__init__.py
+++ b/xbitinfo/__init__.py
@@ -4,3 +4,10 @@ from .bitround import jl_bitround, xr_bitround
 from .graphics import plot_bitinformation, plot_distribution
 from .save_compressed import get_compress_encoding_nc, get_compress_encoding_zarr
 from .xbitinfo import _get_keepbits, get_bitinformation, get_keepbits, get_prefect_flow
+
+from pkg_resources import DistributionNotFound, get_distribution
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:  # pragma: no cover
+    __version__ = '0.0.0'  # pragma: no cover

--- a/xbitinfo/__init__.py
+++ b/xbitinfo/__init__.py
@@ -1,13 +1,13 @@
 """Top-level package for xbitinfo."""
 
+from pkg_resources import DistributionNotFound, get_distribution
+
 from .bitround import jl_bitround, xr_bitround
 from .graphics import plot_bitinformation, plot_distribution
 from .save_compressed import get_compress_encoding_nc, get_compress_encoding_zarr
 from .xbitinfo import _get_keepbits, get_bitinformation, get_keepbits, get_prefect_flow
 
-from pkg_resources import DistributionNotFound, get_distribution
-
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:  # pragma: no cover
-    __version__ = '0.0.0'  # pragma: no cover
+    __version__ = "0.0.0"  # pragma: no cover


### PR DESCRIPTION
- alternative to #80 
- once a tag is created, `xbitinfo.__version__` shows it. if development version is installed, `0.0.1+dirtynumberofcommitssincetag`
- add GHA for release, still need to add pypi secrets in settings, but also works manually