### PR TITLE
add pre/post pytest hooks for clean tmp dir handling

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -19,6 +22,16 @@ def add_standard_imports(
     doctest_namespace["xb"] = xb
     # always seed numpy.random to make the examples deterministic
     np.random.seed(42)
+
+
+def pytest_sessionstart(session):
+    """Run before start of tests"""
+    os.makedirs("./tmp_testdir")
+
+
+def pytest_sessionfinish(session):
+    """Run after finishing tests"""
+    shutil.rmtree("./tmp_testdir")
 
 
 @pytest.fixture()

--- a/tests/test_bitinformation_pipeline.py
+++ b/tests/test_bitinformation_pipeline.py
@@ -16,13 +16,17 @@ def test_full():
     # ds_bitrounded = xb.jl_bitround(ds, keepbits)
     ds_bitrounded = xb.xr_bitround(ds, keepbits)  # identical
     # save
-    ds.to_netcdf(f"{label}.nc")
-    ds.to_compressed_netcdf(f"{label}_compressed.nc")
-    ds_bitrounded.to_compressed_netcdf(f"{label}_bitrounded_compressed.nc")
+    ds.to_netcdf(f"./tmp_testdir/{label}.nc")
+    ds.to_compressed_netcdf(f"./tmp_testdir/{label}_compressed.nc")
+    ds_bitrounded.to_compressed_netcdf(
+        f"./tmp_testdir/{label}_bitrounded_compressed.nc"
+    )
     # check size reduction
-    ori_size = os.path.getsize(f"{label}.nc")
-    compressed_size = os.path.getsize(f"{label}_compressed.nc")
-    bitrounded_compressed_size = os.path.getsize(f"{label}_bitrounded_compressed.nc")
+    ori_size = os.path.getsize(f"./tmp_testdir/{label}.nc")
+    compressed_size = os.path.getsize(f"./tmp_testdir/{label}_compressed.nc")
+    bitrounded_compressed_size = os.path.getsize(
+        f"./tmp_testdir/{label}_bitrounded_compressed.nc"
+    )
     assert compressed_size < ori_size
     assert bitrounded_compressed_size < compressed_size
 
@@ -35,7 +39,7 @@ def flow_paths(rasm):
     paths = []
     stride = rasm.time.size // imax
     for i in range(imax):
-        f = f"file_{i}.nc"
+        f = f"./tmp_testdir/file_{i}.nc"
         if os.path.exists(f.replace(".nc", "_bitrounded_compressed.nc")):
             os.remove(f.replace(".nc", "_bitrounded_compressed.nc"))
         paths.append(f)

--- a/tests/test_get_bitinformation.py
+++ b/tests/test_get_bitinformation.py
@@ -120,11 +120,11 @@ def test_get_bitinformation_confidence():
 def test_get_bitinformation_label(rasm):
     """Test xb.get_bitinformation serializes when label given."""
     ds = rasm
-    xb.get_bitinformation(ds, dim="x", label="rasm")
-    assert os.path.exists("rasm.json")
+    xb.get_bitinformation(ds, dim="x", label="./tmp_testdir/rasm")
+    assert os.path.exists("./tmp_testdir/rasm.json")
     # second call should be faster
-    xb.get_bitinformation(ds, dim="x", label="rasm")
-    os.remove("rasm.json")
+    xb.get_bitinformation(ds, dim="x", label="./tmp_testdir/rasm")
+    os.remove("./tmp_testdir/rasm.json")
 
 
 @pytest.mark.parametrize("dtype", ["float64", "float32", "float16"])

--- a/tests/test_save_compressed.py
+++ b/tests/test_save_compressed.py
@@ -29,11 +29,11 @@ def test_to_compressed_netcdf(rasm, dask):
         ds = ds.chunk("auto")
     label = "file"
     # save
-    ds.to_netcdf(f"{label}.nc")
-    ds.to_compressed_netcdf(f"{label}_compressed.nc")
+    ds.to_netcdf(f"./tmp_testdir/{label}.nc")
+    ds.to_compressed_netcdf(f"./tmp_testdir/{label}_compressed.nc")
     # check size reduction
-    ori_size = os.path.getsize(f"{label}.nc")
-    compressed_size = os.path.getsize(f"{label}_compressed.nc")
+    ori_size = os.path.getsize(f"./tmp_testdir/{label}.nc")
+    compressed_size = os.path.getsize(f"./tmp_testdir/{label}_compressed.nc")
     assert compressed_size < ori_size
 
 
@@ -41,8 +41,8 @@ def test_to_compressed_netcdf_for_cdo_no_time_dim_var(air_temperature):
     """Test to_compressed_netcdf if `for_cdo=True` and one var without `time_dim`."""
     ds = air_temperature
     ds["air_mean"] = ds["air"].isel(time=0)
-    ds.to_compressed_netcdf("test.nc", for_cdo=True)
-    os.remove("test.nc")
+    ds.to_compressed_netcdf("./tmp_testdir/test.nc", for_cdo=True)
+    os.remove("./tmp_testdir/test.nc")
 
 
 def get_zarr_size(fn):
@@ -64,14 +64,14 @@ def test_to_compressed_zarr(rasm):
     encoding = {
         var: {"compressor": None} for var in ds.data_vars
     }  # deactivate default compression
-    ds.to_zarr(f"{label}.zarr", mode="w", encoding=encoding)
-    ds.to_compressed_zarr(f"{label}_compressed.zarr", mode="w")
+    ds.to_zarr(f"./tmp_testdir/{label}.zarr", mode="w", encoding=encoding)
+    ds.to_compressed_zarr(f"./tmp_testdir/{label}_compressed.zarr", mode="w")
     # check size reduction
-    ori_size = get_zarr_size(f"{label}.zarr")
-    compressed_size = get_zarr_size(f"{label}_compressed.zarr")
+    ori_size = get_zarr_size(f"./tmp_testdir/{label}.zarr")
+    compressed_size = get_zarr_size(f"./tmp_testdir/{label}_compressed.zarr")
     assert compressed_size < ori_size
-    shutil.rmtree(f"{label}.zarr")
-    shutil.rmtree(f"{label}_compressed.zarr")
+    shutil.rmtree(f"./tmp_testdir/{label}.zarr")
+    shutil.rmtree(f"./tmp_testdir/{label}_compressed.zarr")
 
 
 def test_to_compressed_zarr_individual_compressors(eraint_uvz):
@@ -82,15 +82,17 @@ def test_to_compressed_zarr_individual_compressors(eraint_uvz):
     encoding = {
         var: {"compressor": None} for var in ds.data_vars
     }  # deactivate default compression
-    ds.to_zarr(f"{label}.zarr", mode="w", encoding=encoding)
+    ds.to_zarr(f"./tmp_testdir/{label}.zarr", mode="w", encoding=encoding)
     compressors = {
         "u": numcodecs.Blosc("zstd", clevel=7),
         "v": numcodecs.Blosc("zlib", clevel=7, shuffle=numcodecs.Blosc.BITSHUFFLE),
     }
-    ds.to_compressed_zarr(f"{label}_compressed.zarr", compressors, mode="w")
+    ds.to_compressed_zarr(
+        f"./tmp_testdir/{label}_compressed.zarr", compressors, mode="w"
+    )
     # check size reduction
-    ori_size = get_zarr_size(f"{label}.zarr")
-    compressed_size = get_zarr_size(f"{label}_compressed.zarr")
+    ori_size = get_zarr_size(f"./tmp_testdir/{label}.zarr")
+    compressed_size = get_zarr_size(f"./tmp_testdir/{label}_compressed.zarr")
     assert compressed_size < ori_size
-    shutil.rmtree(f"{label}.zarr")
-    shutil.rmtree(f"{label}_compressed.zarr")
+    shutil.rmtree(f"./tmp_testdir/{label}.zarr")
+    shutil.rmtree(f"./tmp_testdir/{label}_compressed.zarr")


### PR DESCRIPTION
Some test files are not deleted after `pytest` ran. This is especially true in case some errors occurred in the tests and the files cannot be cleaned within the test-function call. This PR uses the pytest hooks for initialising a temporary directory and removal of the same after all tests ran.