### PR TITLE
refactor `xb.get_keepbits` with `xarray`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ CHANGELOG
 
 * Fix ``kwargs`` in are not reused for other variables in :py:func:`xbitinfo.xbitinfo.get_bitinformation`.
   (:issue:`99`, :pr:`101`) `Aaron Spring`_.
+* Refactor :py:func:`xbitinfo.xbitinfo.get_keepbits` with xarray functions.
+  (:pr:`100`) `Aaron Spring`_.
 
 
 0.0.1 (2022-05-04)

--- a/tests/test_get_keepbits.py
+++ b/tests/test_get_keepbits.py
@@ -28,4 +28,4 @@ def test_get_keepbits_inflevel_dim(rasm_info_per_bit, inflevel):
     assert "inflevel" in keepbits.dims
     if isinstance(inflevel, (int, float)):
         inflevel = [inflevel]
-    assert keepbits.inflevel.size == len(inflevel)
+    assert (keepbits.inflevel == inflevel).all()

--- a/tests/test_get_keepbits.py
+++ b/tests/test_get_keepbits.py
@@ -1,0 +1,31 @@
+"""Tests for `xbitinfo.get_keepbits`."""
+import pytest
+import xarray as xr
+
+import xbitinfo as xb
+
+
+pytest.fixture
+def rasm_info_per_bit(rasm):
+    return xb.get_bitinformation(rasm, axis=0)
+
+
+def test_get_keepbits(rasm_info_per_bit):
+    """Test xb.get_keepbits returns xr.Dataset."""
+    assert isinstance(xb.get_keepbits(rasm_info_per_bit), xr.Dataset)
+
+
+def test_get_keepbits_inflevel_1(rasm_info_per_bit):
+    """Test xb.get_keepbits returns all mantissa bits for inflevel 1."""
+    keepbits = xb.get_keepbits(rasm_info_per_bit, inflevel=1)
+    assert (keepbits == 53).all()
+
+
+@pytest.mark.parametrize("inflevel", [.99, [.99, 1.]])
+def test_get_keepbits_inflevel_dim(rasm_info_per_bit, inflevel):
+    """Test xb.get_keepbits returns inflevel as dim."""
+    keepbits = xb.get_keepbits(rasm_info_per_bit, inflevel=inflevel)
+    assert "inflevel" in keepbits.dims
+    if isinstance(inflevel, [int, float]):
+      inflevel = [inflevel]
+    assert keepbits.inflevel.size == len(inflevel)

--- a/tests/test_get_keepbits.py
+++ b/tests/test_get_keepbits.py
@@ -21,11 +21,11 @@ def test_get_keepbits_inflevel_1(rasm_info_per_bit):
     assert (keepbits == 53).all()
 
 
-@pytest.mark.parametrize("inflevel", [.99, [.99, 1.]])
+@pytest.mark.parametrize("inflevel", [0.99, [0.99, 1.0]])
 def test_get_keepbits_inflevel_dim(rasm_info_per_bit, inflevel):
     """Test xb.get_keepbits returns inflevel as dim."""
     keepbits = xb.get_keepbits(rasm_info_per_bit, inflevel=inflevel)
     assert "inflevel" in keepbits.dims
     if isinstance(inflevel, (int, float)):
-      inflevel = [inflevel]
+        inflevel = [inflevel]
     assert keepbits.inflevel.size == len(inflevel)

--- a/tests/test_get_keepbits.py
+++ b/tests/test_get_keepbits.py
@@ -5,7 +5,7 @@ import xarray as xr
 import xbitinfo as xb
 
 
-pytest.fixture
+@pytest.fixture
 def rasm_info_per_bit(rasm):
     return xb.get_bitinformation(rasm, axis=0)
 
@@ -26,6 +26,6 @@ def test_get_keepbits_inflevel_dim(rasm_info_per_bit, inflevel):
     """Test xb.get_keepbits returns inflevel as dim."""
     keepbits = xb.get_keepbits(rasm_info_per_bit, inflevel=inflevel)
     assert "inflevel" in keepbits.dims
-    if isinstance(inflevel, [int, float]):
+    if isinstance(inflevel, (int, float)):
       inflevel = [inflevel]
     assert keepbits.inflevel.size == len(inflevel)

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -344,7 +344,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
                     "inflevel",
                 ).sel(inflevel=keepmantissabits_bitdim.inflevel)
             keepmantissabits.append(keepmantissabits_bitdim)
-    return xr.merge(keepmantissabits).squeeze(dim="inflevel")
+    return xr.merge(keepmantissabits) #  .squeeze(dim="inflevel")
 
 
 def _jl_bitround(X, keepbits):

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -324,7 +324,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
         bit_vars = [v for v in info_per_bit.data_vars if bitdim in info_per_bit[v].dims]
         if bit_vars != []:
             cdf = _cdf_from_info_per_bit(info_per_bit[bit_vars], bitdim)
-            bitdim_non_mantissa_bits = NMBITS[int(bitdim[3:])
+            bitdim_non_mantissa_bits = NMBITS[int(bitdim[3:])]
             keepmantissabits_bitdim = (
                 (cdf > inflevel).argmax(bitdim) + 1 - bitdim_non_mantissa_bits]
             )

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -345,7 +345,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
                     "inflevel",
                 ).sel(inflevel=keepmantissabits_bitdim.inflevel)
             keepmantissabits.append(keepmantissabits_bitdim)
-    return xr.merge(keepmantissabits).transpose()
+    return xr.merge(keepmantissabits)
 
 
 def _jl_bitround(X, keepbits):

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -334,7 +334,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
             (cdf > inflevel).argmax(bitdim) + 1 - NMBITS[int(bitdim[3:])]
         )
         # keep all for 100% information
-        if 1.0 in inflevels:
+        if 1.0 in inflevel:
             keepall = xr.ones_like(keepmantissabits_bitdim) * (
                 int(bitdim[3:]) - NMBITS[int(bitdim[3:])]
             )

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -334,9 +334,13 @@ def get_keepbits(info_per_bit, inflevel=0.99):
             (cdf > inflevel).argmax(bitdim) + 1 - NMBITS[int(bitdim[3:])]
         )
         # keep all for 100% information
-        if 1. in inflevels:
-            keepall = xr.ones_like(xb.get_keepbits(info_per_bit)) * (int(bitdim[3:]) - NMBITS[int(bitdim[3:])])
-            keepmantissabits_bitdim = xr.concat([keepmantissabits_bitdim.drop_sel(inflevel=1.), keepall], "inflevel").sel(inflevel=keepmantissabits_bitdim.inflevel)            
+        if 1.0 in inflevels:
+            keepall = xr.ones_like(xb.get_keepbits(info_per_bit)) * (
+                int(bitdim[3:]) - NMBITS[int(bitdim[3:])]
+            )
+            keepmantissabits_bitdim = xr.concat(
+                [keepmantissabits_bitdim.drop_sel(inflevel=1.0), keepall], "inflevel"
+            ).sel(inflevel=keepmantissabits_bitdim.inflevel)
         keepmantissabits.append(keepmantissabits_bitdim)
     return xr.merge(keepmantissabits)
 

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -349,8 +349,7 @@ def _cdf_from_info_per_bit(info_per_bit, bitdim):
     """Convert info_per_bit to cumulative distribution function on dimension bitdim."""
     # set below rounding error from last digit to zero
     info_per_bit_cleaned = info_per_bit.where(
-        info_per_bit
-        > info_per_bit.isel({bitdim: slice(-4, None)}).max(bitdim) * 1.5
+        info_per_bit > info_per_bit.isel({bitdim: slice(-4, None)}).max(bitdim) * 1.5
     )
     # make cumulative distribution function
     cdf = info_per_bit_cleaned.cumsum(bitdim) / info_per_bit_cleaned.cumsum(

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -319,8 +319,12 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     inflevel = xr.DataArray(inflevel, dims="inflevel", coords={"inflevel": inflevel})
     if (inflevel < 0).any() or (inflevel > 1.0).any():
         raise ValueError("Please provide `inflevel` from interval [0.,1.]")
-    info_per_bit_cleaned = info_per_bit.where(info_per_bit>info_per_bit.isel({bitdim:slice(-4,None)}).max(bitdim)*1.5)
-    cdf = (info_per_bit_cleaned.cumsum(bitdim)/info_per_bit_cleaned.cumsum(bitdim).isel({bitdim:-1}))
+    info_per_bit_cleaned = info_per_bit.where(
+        info_per_bit > info_per_bit.isel({bitdim: slice(-4, None)}).max(bitdim) * 1.5
+    )
+    cdf = info_per_bit_cleaned.cumsum(bitdim) / info_per_bit_cleaned.cumsum(
+        bitdim
+    ).isel({bitdim: -1})
     keepmantissabits = (cdf > inflevel).argmax(bitdim) + 1 - NMBITS[int(bitdim[3:])]
     return keepmantissabits
 

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -316,7 +316,11 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     # - shortcut for  == 1.0: keepmantissabits_inflevels[il] = len(ic) - NMBITS[len(ic)]
     # - loop over dim if bitdim multiple present
     bitdim = "bit32"
-    inflevel = xr.DataArray(inflevel, dims="inflevel" if isinstance(inflevel, list) else None, coords={"inflevel": inflevel})
+    inflevel = xr.DataArray(
+        inflevel,
+        dims="inflevel" if isinstance(inflevel, list) else None,
+        coords={"inflevel": inflevel},
+    )
     if (inflevel < 0).any() or (inflevel > 1.0).any():
         raise ValueError("Please provide `inflevel` from interval [0.,1.]")
     info_per_bit_cleaned = info_per_bit.where(

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -318,18 +318,23 @@ def get_keepbits(info_per_bit, inflevel=0.99):
         inflevel = [inflevel]
     keepmantissabits = []
     for bitdim in ["bit16", "bit32", "bit64"]:
-        inflevel = xr.DataArray(inflevel, dims="inflevel", coords={"inflevel": inflevel})
+        inflevel = xr.DataArray(
+            inflevel, dims="inflevel", coords={"inflevel": inflevel}
+        )
         if (inflevel < 0).any() or (inflevel > 1.0).any():
             raise ValueError("Please provide `inflevel` from interval [0.,1.]")
         # get only variables of bitdim
         bit_vars = [v for v in info_per_bit.data_vars if bitdim in info_per_bit[v].dims]
         info_per_bit_cleaned = info_per_bit[bit_vars].where(
-            info_per_bit > info_per_bit.isel({bitdim: slice(-4, None)}).max(bitdim) * 1.5
+            info_per_bit
+            > info_per_bit.isel({bitdim: slice(-4, None)}).max(bitdim) * 1.5
         )
         cdf = info_per_bit_cleaned.cumsum(bitdim) / info_per_bit_cleaned.cumsum(
             bitdim
         ).isel({bitdim: -1})
-        keepmantissabits_bitdim = (cdf > inflevel).argmax(bitdim) + 1 - NMBITS[int(bitdim[3:])]
+        keepmantissabits_bitdim = (
+            (cdf > inflevel).argmax(bitdim) + 1 - NMBITS[int(bitdim[3:])]
+        )
         keepmantissabits.append(keepmantissabits_bitdim)
     return xr.merge(keepmantissabits)
 

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -316,7 +316,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     # - shortcut for  == 1.0: keepmantissabits_inflevels[il] = len(ic) - NMBITS[len(ic)]
     # - loop over dim if bitdim multiple present
     bitdim = "bit32"
-    inflevel = xr.DataArray(inflevel, dims="inflevel", coords={"inflevel": inflevel})
+    inflevel = xr.DataArray(inflevel, dims="inflevel" if isinstance(inflevel, list) else None, coords={"inflevel": inflevel})
     if (inflevel < 0).any() or (inflevel > 1.0).any():
         raise ValueError("Please provide `inflevel` from interval [0.,1.]")
     info_per_bit_cleaned = info_per_bit.where(

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -344,7 +344,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
                     "inflevel",
                 ).sel(inflevel=keepmantissabits_bitdim.inflevel)
             keepmantissabits.append(keepmantissabits_bitdim)
-    return xr.merge(keepmantissabits) #  .squeeze(dim="inflevel")
+    return xr.merge(keepmantissabits)  #  .squeeze(dim="inflevel")
 
 
 def _jl_bitround(X, keepbits):

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -316,11 +316,9 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     # - shortcut for  == 1.0: keepmantissabits_inflevels[il] = len(ic) - NMBITS[len(ic)]
     # - loop over dim if bitdim multiple present
     bitdim = "bit32"
-    inflevel = xr.DataArray(
-        inflevel,
-        dims="inflevel" if isinstance(inflevel, list) else None,
-        coords={"inflevel": inflevel},
-    )
+    if isinstance(inflevel, list):
+        inflevel = [inflevel]
+    inflevel = xr.DataArray(inflevel, dims="inflevel", coords={"inflevel": inflevel})
     if (inflevel < 0).any() or (inflevel > 1.0).any():
         raise ValueError("Please provide `inflevel` from interval [0.,1.]")
     info_per_bit_cleaned = info_per_bit.where(

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -337,13 +337,13 @@ def get_keepbits(info_per_bit, inflevel=0.99):
             )
             # keep all for 100% information
             if 1.0 in inflevel:
-                keepall = xr.ones_like(keepmantissabits_bitdim.sel(inflevel=1.)) * (
+                keepall = xr.ones_like(keepmantissabits_bitdim.sel(inflevel=1.0)) * (
                     int(bitdim[3:]) - NMBITS[int(bitdim[3:])]
                 )
                 keepmantissabits_bitdim = xr.concat(
                     [keepmantissabits_bitdim.drop_sel(inflevel=1.0), keepall],
                     "inflevel",
-                ) 
+                )
             keepmantissabits.append(keepmantissabits_bitdim)
     return xr.merge(keepmantissabits)
 

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -345,7 +345,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
                     "inflevel",
                 ).sel(inflevel=keepmantissabits_bitdim.inflevel)
             keepmantissabits.append(keepmantissabits_bitdim)
-    return xr.merge(keepmantissabits)  #  .squeeze(dim="inflevel")
+    return xr.merge(keepmantissabits).transpose()
 
 
 def _jl_bitround(X, keepbits):

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -315,14 +315,12 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     """
     if not isinstance(inflevel, list):
         inflevel = [inflevel]
-    keepmantissabits = [] 
-    inflevel = xr.DataArray(
-        inflevel, dims="inflevel", coords={"inflevel": inflevel}
-    )
+    keepmantissabits = []
+    inflevel = xr.DataArray(inflevel, dims="inflevel", coords={"inflevel": inflevel})
     if (inflevel < 0).any() or (inflevel > 1.0).any():
         raise ValueError("Please provide `inflevel` from interval [0.,1.]")
     for bitdim in ["bit16", "bit32", "bit64"]:
-        # get only variables of bitdim 
+        # get only variables of bitdim
         bit_vars = [v for v in info_per_bit.data_vars if bitdim in info_per_bit[v].dims]
         if bit_vars != []:
             info_per_bit_cleaned = info_per_bit[bit_vars].where(
@@ -346,9 +344,10 @@ def get_keepbits(info_per_bit, inflevel=0.99):
                 )
             keepmantissabits.append(keepmantissabits_bitdim)
     keepmantissabits = xr.merge(keepmantissabits)
-    if inflevel.inflevel.size > 1: # restore orginal ordering
+    if inflevel.inflevel.size > 1:  # restore orginal ordering
         keepmantissabits = keepmantissabits.sel(inflevel=inflevel.inflevel)
     return keepmantissabits
+
 
 def _jl_bitround(X, keepbits):
     """Wrap `BitInformation.jl.round <https://github.com/milankl/BitInformation.jl/blob/main/src/round_nearest.jl>`__. Used in :py:func:`xbitinfo.bitround.jl_bitround`."""

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -344,7 +344,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
                     "inflevel",
                 ).sel(inflevel=keepmantissabits_bitdim.inflevel)
             keepmantissabits.append(keepmantissabits_bitdim)
-    return xr.merge(keepmantissabits)
+    return xr.merge(keepmantissabits).squeeze(dim="inflevel")
 
 
 def _jl_bitround(X, keepbits):

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -319,7 +319,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     inflevel = xr.DataArray(inflevel, dims="inflevel", coords={"inflevel": inflevel})
     if (inflevel < 0).any() or (inflevel > 1.0).any():
         raise ValueError("Please provide `inflevel` from interval [0.,1.]")
-    info_per_bit_cleaned = info_per_bit.where(info_per_bit>info_per_bit.isel({bitdim:slice(-4,None)).max(bitdim)*1.5})
+    info_per_bit_cleaned = info_per_bit.where(info_per_bit>info_per_bit.isel({bitdim:slice(-4,None)}).max(bitdim)*1.5)
     cdf = (info_per_bit_cleaned.cumsum(bitdim)/info_per_bit_cleaned.cumsum(bitdim).isel({bitdim:-1}))
     keepmantissabits = (cdf > inflevel).argmax(bitdim) + 1 - NMBITS[int(bitdim[3:])]
     return keepmantissabits

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -337,13 +337,13 @@ def get_keepbits(info_per_bit, inflevel=0.99):
             )
             # keep all for 100% information
             if 1.0 in inflevel:
-                keepall = xr.ones_like(keepmantissabits_bitdim) * (
+                keepall = xr.ones_like(keepmantissabits_bitdim.sel(inflevel=1.)) * (
                     int(bitdim[3:]) - NMBITS[int(bitdim[3:])]
                 )
                 keepmantissabits_bitdim = xr.concat(
                     [keepmantissabits_bitdim.drop_sel(inflevel=1.0), keepall],
                     "inflevel",
-                ).sel(inflevel=keepmantissabits_bitdim.inflevel)
+                ) 
             keepmantissabits.append(keepmantissabits_bitdim)
     return xr.merge(keepmantissabits)
 

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -283,24 +283,24 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     <xarray.Dataset>
     Dimensions:   (inflevel: 1)
     Coordinates:
-      * inflevel  (inflevel) float64 0.99
         dim       <U3 'lon'
+      * inflevel  (inflevel) float64 0.99
     Data variables:
         air       (inflevel) int64 7
     >>> xb.get_keepbits(info_per_bit, inflevel=0.99999999)
     <xarray.Dataset>
     Dimensions:   (inflevel: 1)
     Coordinates:
-      * inflevel  (inflevel) float64 1.0
         dim       <U3 'lon'
+      * inflevel  (inflevel) float64 1.0
     Data variables:
         air       (inflevel) int64 14
     >>> xb.get_keepbits(info_per_bit, inflevel=1.0)
     <xarray.Dataset>
     Dimensions:   (inflevel: 1)
     Coordinates:
-      * inflevel  (inflevel) float64 1.0
         dim       <U3 'lon'
+      * inflevel  (inflevel) float64 1.0
     Data variables:
         air       (inflevel) int64 23
     >>> info_per_bit = xb.get_bitinformation(ds)
@@ -308,8 +308,8 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     <xarray.Dataset>
     Dimensions:   (inflevel: 1, dim: 3)
     Coordinates:
-      * inflevel  (inflevel) float64 0.99
       * dim       (dim) <U4 'lat' 'lon' 'time'
+      * inflevel  (inflevel) float64 0.99
     Data variables:
         air       (dim, inflevel) int64 5 7 6
     """

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -335,7 +335,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
         )
         # keep all for 100% information
         if 1.0 in inflevels:
-            keepall = xr.ones_like(xb.get_keepbits(info_per_bit)) * (
+            keepall = xr.ones_like(keepmantissabits_bitdim) * (
                 int(bitdim[3:]) - NMBITS[int(bitdim[3:])]
             )
             keepmantissabits_bitdim = xr.concat(

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -315,14 +315,14 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     """
     if not isinstance(inflevel, list):
         inflevel = [inflevel]
-    keepmantissabits = []
+    keepmantissabits = [] 
+    inflevel = xr.DataArray(
+        inflevel, dims="inflevel", coords={"inflevel": inflevel}
+    )
+    if (inflevel < 0).any() or (inflevel > 1.0).any():
+        raise ValueError("Please provide `inflevel` from interval [0.,1.]")
     for bitdim in ["bit16", "bit32", "bit64"]:
-        inflevel = xr.DataArray(
-            inflevel, dims="inflevel", coords={"inflevel": inflevel}
-        )
-        if (inflevel < 0).any() or (inflevel > 1.0).any():
-            raise ValueError("Please provide `inflevel` from interval [0.,1.]")
-        # get only variables of bitdim
+        # get only variables of bitdim 
         bit_vars = [v for v in info_per_bit.data_vars if bitdim in info_per_bit[v].dims]
         if bit_vars != []:
             info_per_bit_cleaned = info_per_bit[bit_vars].where(
@@ -345,8 +345,10 @@ def get_keepbits(info_per_bit, inflevel=0.99):
                     "inflevel",
                 )
             keepmantissabits.append(keepmantissabits_bitdim)
-    return xr.merge(keepmantissabits)
-
+    keepmantissabits = xr.merge(keepmantissabits)
+    if inflevel.inflevel.size > 1: # restore orginal ordering
+        keepmantissabits = keepmantissabits.sel(inflevel=inflevel.inflevel)
+    return keepmantissabits
 
 def _jl_bitround(X, keepbits):
     """Wrap `BitInformation.jl.round <https://github.com/milankl/BitInformation.jl/blob/main/src/round_nearest.jl>`__. Used in :py:func:`xbitinfo.bitround.jl_bitround`."""

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -340,7 +340,8 @@ def get_keepbits(info_per_bit, inflevel=0.99):
                     int(bitdim[3:]) - NMBITS[int(bitdim[3:])]
                 )
                 keepmantissabits_bitdim = xr.concat(
-                    [keepmantissabits_bitdim.drop_sel(inflevel=1.0), keepall], "inflevel"
+                    [keepmantissabits_bitdim.drop_sel(inflevel=1.0), keepall],
+                    "inflevel",
                 ).sel(inflevel=keepmantissabits_bitdim.inflevel)
             keepmantissabits.append(keepmantissabits_bitdim)
     return xr.merge(keepmantissabits)

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -306,7 +306,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     >>> info_per_bit = xb.get_bitinformation(ds)
     >>> xb.get_keepbits(info_per_bit)
     <xarray.Dataset>
-    Dimensions:   (inflevel: 1, dim: 3)
+    Dimensions:   (dim: 3, inflevel: 1)
     Coordinates:
       * dim       (dim) <U4 'lat' 'lon' 'time'
       * inflevel  (inflevel) float64 0.99

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -312,7 +312,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     Data variables:
         air       (dim, inflevel) int64 5 7 6
     """
-    if isinstance(inflevel, list):
+    if not isinstance(inflevel, list):
         inflevel = [inflevel]
     keepmantissabits = []
     for bitdim in ["bit16", "bit32", "bit64"]:

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -312,8 +312,6 @@ def get_keepbits(info_per_bit, inflevel=0.99):
     Data variables:
         air       (dim, inflevel) int64 5 7 6
     """
-    # todo:
-    # - shortcut for  == 1.0: keepmantissabits_inflevels[il] = len(ic) - NMBITS[len(ic)]
     if isinstance(inflevel, list):
         inflevel = [inflevel]
     keepmantissabits = []
@@ -335,6 +333,10 @@ def get_keepbits(info_per_bit, inflevel=0.99):
         keepmantissabits_bitdim = (
             (cdf > inflevel).argmax(bitdim) + 1 - NMBITS[int(bitdim[3:])]
         )
+        # keep all for 100% information
+        if 1. in inflevels:
+            keepall = xr.ones_like(xb.get_keepbits(info_per_bit)) * (int(bitdim[3:]) - NMBITS[int(bitdim[3:])])
+            keepmantissabits_bitdim = xr.concat([keepmantissabits_bitdim.drop_sel(inflevel=1.), keepall], "inflevel").sel(inflevel=keepmantissabits_bitdim.inflevel)            
         keepmantissabits.append(keepmantissabits_bitdim)
     return xr.merge(keepmantissabits)
 

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -326,7 +326,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
             cdf = _cdf_from_info_per_bit(info_per_bit[bit_vars], bitdim)
             bitdim_non_mantissa_bits = NMBITS[int(bitdim[3:])]
             keepmantissabits_bitdim = (
-                (cdf > inflevel).argmax(bitdim) + 1 - bitdim_non_mantissa_bits]
+                (cdf > inflevel).argmax(bitdim) + 1 - bitdim_non_mantissa_bits
             )
             # keep all mantissa bits for 100% information
             if 1.0 in inflevel:


### PR DESCRIPTION
I thought this PR would be more readable and faster because of more `xarray` operations and less looping, but I was so wrong on speed and also readability didnt improve that much:
```python
ds = xr.tutorial.load_dataset("air_temperature")
info_per_bit = xb.get_bitinformation(ds, dim="lon", masked_value=None)
```
![image](https://user-images.githubusercontent.com/12237157/167663743-65f53b35-f790-467f-8376-74bf2e36b9e6.png)

The only thing it does is saving us a few lines of code... @observingClouds do you think it is useful. I'm ready to close this PR without merge also.

New:
- `get_keepbits` now works on multi-dim inputs
- tests - how could we forget them before???