### PR TITLE
Remove dependency on rabernat branch

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -24,5 +24,5 @@ dependencies:
   - myst-nb
   - pip
   - pip:
-    - git+https://github.com/rabernat/numcodecs@bitround
+    - git+https://github.com/zarr-developers/numcodecs
     - -e ../.

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,6 @@ dependencies:
   - myst-nb
   - pip
   - pip:
-    - git+https://github.com/rabernat/numcodecs@bitround
+    - git+https://github.com/zarr-developers/numcodecs
     - pytest-lazy-fixture
     - -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 xarray
 julia
 tqdm
-numcodecs @ git+https://github.com/rabernat/numcodecs@bitround
+numcodecs @ git+https://github.com/zarr-developers/numcodecs


### PR DESCRIPTION
Now that https://github.com/zarr-developers/numcodecs/pull/299 was merged. 