### PR TITLE
deactivate default compression when writing to zarr

### DIFF
--- a/docs/quick-start.ipynb
+++ b/docs/quick-start.ipynb
@@ -204,7 +204,9 @@
    "source": [
     "ds_bitrounded.to_compressed_zarr(\"bitrounded_compressed.zarr\", mode=\"w\")\n",
     "ds.to_compressed_zarr(\"compressed.zarr\", mode=\"w\")\n",
-    "ds.to_zarr(\"original.zarr\", mode=\"w\");"
+    "ds.to_zarr(\n",
+    "    \"original.zarr\", mode=\"w\", encoding={v: {\"compressor\": None} for v in ds.data_vars}\n",
+    ");"
    ]
   },
   {


### PR DESCRIPTION
fixes #119 