### PR TITLE
drop setuptools_scm_git_archive and use a version file instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ ENV/
 # IDE settings
 .vscode/
 .idea/
+
+# setuptools-scm will bundled that in the sdist but we don't want it tracked
+xbitinfo/_version.py

--- a/setup.py
+++ b/setup.py
@@ -84,10 +84,13 @@ setup(
     tests_require=test_requirements,
     url="https://github.com/observingClouds/xbitinfo",
     zip_safe=False,
-    use_scm_version={"version_scheme": "post-release", "local_scheme": "dirty-tag"},
     setup_requires=[
         "setuptools_scm",
         "setuptools>=30.3.0",
-        "setuptools_scm_git_archive",
     ],
+    use_scm_version={
+        "write_to": "xbitinfo/_version.py",
+        "write_to_template": '__version__ = "{version}"',
+        "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
+    },
 )

--- a/xbitinfo/__init__.py
+++ b/xbitinfo/__init__.py
@@ -1,6 +1,10 @@
 """Top-level package for xbitinfo."""
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "unknown"
+
 from .bitround import jl_bitround, xr_bitround
 from .graphics import plot_bitinformation, plot_distribution
 from .save_compressed import get_compress_encoding_nc, get_compress_encoding_zarr

--- a/xbitinfo/_version.py
+++ b/xbitinfo/_version.py
@@ -1,6 +1,0 @@
-from pkg_resources import DistributionNotFound, get_distribution
-
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: no cover
-    __version__ = "0.0.0"  # pragma: no cover


### PR DESCRIPTION
When working on https://github.com/conda-forge/staged-recipes/pull/20116 I noted that the version was 0.0.0. That is a known "bug" in `setuptools_scm_git_archive` b/c it requires to be on the git tree to work properly, rendering sdist tarballs versionless.

The approach in this PR is the one recommended by PyPA. setuptools-scm writes a version file that is not tracked but it is shipped with the sdist, ensuring the tagged versions is correct.

I also changed the fallback version to "unknown" instead of 0.0.0. The former is an error while the later may be seen as a real version even though it can be any version before this PR.