### PR TITLE
Remove debug

### DIFF
--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -15,7 +15,7 @@ if not already_ran:
     already_ran = install(quiet=True)
 
 
-jl = Julia(compiled_modules=False, debug=True)
+jl = Julia(compiled_modules=False, debug=False)
 from julia import Main  # noqa: E402
 
 path_to_julia_functions = os.path.join(

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -353,7 +353,7 @@ def get_keepbits(info_per_bit, inflevel=0.99):
                 )
             keepmantissabits.append(keepmantissabits_bitdim)
     keepmantissabits = xr.merge(keepmantissabits)
-    if inflevel.inflevel.size > 1:  # restore orginal ordering
+    if inflevel.inflevel.size > 1:  # restore original ordering
         keepmantissabits = keepmantissabits.sel(inflevel=inflevel.inflevel)
     return keepmantissabits
 


### PR DESCRIPTION
While we could make this configurable it was never meant to be `True` in production. Also, it seems that latest updates in PyCall is very verbose, making it quite noisy and confusing to have this `debug=True` here.

Pinging @rsignell-usgs who showed me this in his installation.