### PR TITLE
keep attrs of get_bitinformation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 * Fix julia package installations for PyPi and enable installation via pip and conda (:issue:`18`, :pr:`132`, :pr:`131`) `Filipe Fernandes`_, `Mark Kittisopikul`_.
 * Fix compression example for zarr-files (:issue:`119`, :pr:`121`) `Hauke Schulz`_.
+* Keep ``attrs`` from input :py:func:`xbitinfo.xbitinfo.get_bitinformation`. (:issue:`154`, :pr:`158`) `Aaron Spring`_.
 
 0.0.2 (2022-07-11)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ CHANGELOG
 
 * Fix julia package installations for PyPi and enable installation via pip and conda (:issue:`18`, :pr:`132`, :pr:`131`) `Filipe Fernandes`_, `Mark Kittisopikul`_.
 * Fix compression example for zarr-files (:issue:`119`, :pr:`121`) `Hauke Schulz`_.
-* Keep ``attrs`` from input :py:func:`xbitinfo.xbitinfo.get_bitinformation`. (:issue:`154`, :pr:`158`) `Aaron Spring`_.
+* Keep ``attrs`` as ``source_attribute`` from input in :py:func:`xbitinfo.xbitinfo.get_bitinformation`. (:issue:`154`, :pr:`158`) `Aaron Spring`_.
 
 0.0.2 (2022-07-11)
 ------------------

--- a/tests/test_get_bitinformation.py
+++ b/tests/test_get_bitinformation.py
@@ -215,3 +215,10 @@ def test_get_bitinformation_different_dtypes(rasm, implementation):
 def test_get_bitinformation_dim_list(rasm, implementation):
     bi = xb.get_bitinformation(rasm, dim=["x", "y"], implementation=implementation)
     assert (bi.dim == ["x", "y"]).all()
+
+
+def test_get_bitinformation_keep_attrs(rasm):
+    bi = xb.get_bitinformation(rasm, dim=["x", "y"]).Tair
+    assert "bitinfo_units" in bi.attrs
+    assert bi.attrs["bitinfo_units"] == 1
+    assert set(rasm.Tair.attrs.keys()).issubset(bi.attrs.keys())

--- a/tests/test_get_bitinformation.py
+++ b/tests/test_get_bitinformation.py
@@ -222,4 +222,4 @@ def test_get_bitinformation_keep_attrs(rasm):
     assert "units" in bi.attrs
     assert bi.attrs["units"] == 1
     for a in rasm.Tair.attrs.keys():
-        assert bi.Tair.attrs["source_" + a] == rasm.Tair.attrs[a]
+        assert bi.attrs["source_" + a] == rasm.Tair.attrs[a]

--- a/tests/test_get_bitinformation.py
+++ b/tests/test_get_bitinformation.py
@@ -219,6 +219,7 @@ def test_get_bitinformation_dim_list(rasm, implementation):
 
 def test_get_bitinformation_keep_attrs(rasm):
     bi = xb.get_bitinformation(rasm, dim=["x", "y"]).Tair
-    assert "bitinfo_units" in bi.attrs
-    assert bi.attrs["bitinfo_units"] == 1
-    assert set(rasm.Tair.attrs.keys()).issubset(bi.attrs.keys())
+    assert "units" in bi.attrs
+    assert bi.attrs["units"] == 1
+    for a in rasm.Tair.attrs.keys():
+        assert bi.Tair.attrs["source_" + a] == rasm.Tair.attrs[a]

--- a/tests/test_get_bitinformation.py
+++ b/tests/test_get_bitinformation.py
@@ -222,4 +222,4 @@ def test_get_bitinformation_keep_attrs(rasm):
     assert "units" in bi.attrs
     assert bi.attrs["units"] == 1
     for a in rasm.Tair.attrs.keys():
-        assert bi.attrs["source_" + a] == rasm.Tair.attrs[a]
+        assert bi.attrs["source_" + a] == rasm.Tair.attrs[a], print(bi.attrs)

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -68,7 +68,10 @@ def dict_to_dataset(info_per_bit):
             dims=[dim_name],
             coords={dim_name: get_bit_coords(dtype_size), "dim": dim},
             name=v,
-            attrs={"bitinfo_long_name": f"{v} bitwise information", "bitinfo_units": "1"},
+            attrs={
+                "bitinfo_long_name": f"{v} bitwise information",
+                "bitinfo_units": "1",
+            },
         ).astype("float64")
     # add metadata
     dsb.attrs = {
@@ -237,7 +240,7 @@ def get_bitinformation(
                 logging.debug(f"Save bitinformation to {label + '.json'}")
                 json.dump(info_per_bit, f, cls=JsonCustomEncoder)
     info_per_bit = dict_to_dataset(info_per_bit)
-    for var in info_per_bit.data_vars: # keep attrs from input
+    for var in info_per_bit.data_vars:  # keep attrs from input
         info_per_bit[var].attrs.update(ds[var].attrs)
     return info_per_bit
 

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -68,7 +68,7 @@ def dict_to_dataset(info_per_bit):
             dims=[dim_name],
             coords={dim_name: get_bit_coords(dtype_size), "dim": dim},
             name=v,
-            attrs={"long_name": f"{v} bitwise information", "units": "1"},
+            attrs={"bitinfo_long_name": f"{v} bitwise information", "bitinfo_units": "1"},
         ).astype("float64")
     # add metadata
     dsb.attrs = {
@@ -236,7 +236,10 @@ def get_bitinformation(
             with open(label + ".json", "w") as f:
                 logging.debug(f"Save bitinformation to {label + '.json'}")
                 json.dump(info_per_bit, f, cls=JsonCustomEncoder)
-    return dict_to_dataset(info_per_bit)
+    info_per_bit = dict_to_dataset(info_per_bit)
+    for var in info_per_bit.data_vars: # keep attrs from input
+        info_per_bit[var].attrs.update(ds[var].attrs)
+    return info_per_bit
 
 
 def _jl_get_bitinformation(ds, var, axis, dim, kwargs={}):

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -70,7 +70,7 @@ def dict_to_dataset(info_per_bit):
             name=v,
             attrs={
                 "bitinfo_long_name": f"{v} bitwise information",
-                "bitinfo_units": "1",
+                "bitinfo_units": 1,
             },
         ).astype("float64")
     # add metadata

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -242,7 +242,7 @@ def get_bitinformation(  # noqa: C901
     info_per_bit = dict_to_dataset(info_per_bit)
     for var in info_per_bit.data_vars:  # keep attrs from input with source_ prefix
         for a in ds[var].attrs.keys():
-            info_per_bit[var].attrs["source" + a] = ds[var].attrs[a]
+            info_per_bit[var].attrs["source_" + a] = ds[var].attrs[a]
     return info_per_bit
 
 

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -93,7 +93,7 @@ def dict_to_dataset(info_per_bit):
     return dsb
 
 
-def get_bitinformation( # noqa: C901
+def get_bitinformation(  # noqa: C901
     ds,
     dim=None,
     axis=None,

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -93,7 +93,7 @@ def dict_to_dataset(info_per_bit):
     return dsb
 
 
-def get_bitinformation(
+def get_bitinformation( # noqa: C901
     ds,
     dim=None,
     axis=None,

--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -69,8 +69,8 @@ def dict_to_dataset(info_per_bit):
             coords={dim_name: get_bit_coords(dtype_size), "dim": dim},
             name=v,
             attrs={
-                "bitinfo_long_name": f"{v} bitwise information",
-                "bitinfo_units": 1,
+                "long_name": f"{v} bitwise information",
+                "units": 1,
             },
         ).astype("float64")
     # add metadata
@@ -240,8 +240,9 @@ def get_bitinformation(  # noqa: C901
                 logging.debug(f"Save bitinformation to {label + '.json'}")
                 json.dump(info_per_bit, f, cls=JsonCustomEncoder)
     info_per_bit = dict_to_dataset(info_per_bit)
-    for var in info_per_bit.data_vars:  # keep attrs from input
-        info_per_bit[var].attrs.update(ds[var].attrs)
+    for var in info_per_bit.data_vars:  # keep attrs from input with source_ prefix
+        for a in ds[var].attrs.keys():
+            info_per_bit[var].attrs["source" + a] = ds[var].attrs[a]
     return info_per_bit
 
 


### PR DESCRIPTION
closes #154 

- changes `units` to `bitinfo_units`
- changes `long_name` to `bitinfo_long_name`
- keep input attrs 
