### PR TITLE
more info in progress bar

### DIFF
--- a/xbitinfo/xbitinfo.py
+++ b/xbitinfo/xbitinfo.py
@@ -215,7 +215,7 @@ def get_bitinformation(
         info_per_bit = {}
         pbar = tqdm(ds.data_vars)
         for var in pbar:
-            pbar.set_description("Processing %s" % var)
+            pbar.set_description(f"Processing var: {var} for dim: {dim}")
             if implementation == "julia":
                 info_per_bit_var = _jl_get_bitinformation(ds, var, axis, dim, kwargs)
                 if info_per_bit_var is None:


### PR DESCRIPTION
`xb.get_bitinformation(ds)` shows

Processing sst: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:06<00:00,  6.39s/it]
Processing sst: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.34s/it]
Processing sst: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.20s/it]

This updated message shows that's running over the dimensions.

can test the f-string as
var = "a"
dim = "b"
f"Processing var: {var} for dim: {dim}"
