### PR TITLE
add pooch to requirements, dependency of tutorial.open_dataset

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dask
 xarray
 tqdm
+pooch
 numcodecs>=0.10.0


### PR DESCRIPTION
Adding `pooch` to **`requirements.txt`**, as `tutorial.open_dataset` depends on it to download and manage datasets.
Before:
![image](https://user-images.githubusercontent.com/63267601/229652899-ebcbb6fa-869a-4132-8c87-5395de9f1b29.png)
After:
![image](https://user-images.githubusercontent.com/63267601/229653167-58cdc4cd-e193-4533-9cb1-9c133ebd3618.png)
