### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       # We need the full repo to avoid this issue
       # https://github.com/actions/checkout/issues/23
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           # installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
           installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
@@ -74,7 +74,7 @@ jobs:
           cp benchmarks.log .asv/results/
         working-directory: ${{ env.ASV_DIR }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3.1.2
         if: always()
         with:
           name: asv-benchmark-results-${{ runner.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,10 @@ jobs:
     outputs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 2
-      - uses: xarray-contrib/ci-trigger@v1.1
+      - uses: xarray-contrib/ci-trigger@v1.2
         id: detect-trigger
         with:
           keyword: "[skip-ci]"
@@ -33,11 +33,11 @@ jobs:
         run:
           shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
         with:
             fetch-depth: 0 # Fetch all history for all branches and tags.
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           auto-update-conda: false
           channels: conda-forge
@@ -64,8 +64,8 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v3.5.2
+      - uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           channels: conda-forge
           miniforge-variant: Mambaforge
@@ -95,9 +95,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.2.5.2
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           auto-update-conda: false
           channels: conda-forge
@@ -129,15 +129,15 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.5.2
       with:
         fetch-depth: 0 # Fetch all history for all branches and tags.
     - name: Setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4.6.0
       with:
         python-version: "3.11"
     - name: "Set up Julia"
-      uses: julia-actions/setup-julia@v1.6.0
+      uses: julia-actions/setup-julia@v1.9.2
       with:
         version: "1.7.1"
     - name: Install dependencies

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,10 +13,10 @@ jobs:
   packages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.5.2
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4.6.0
       with:
         python-version: "3.10"
 
@@ -45,7 +45,7 @@ jobs:
 
     - name: Publish a Python distribution to PyPI
       if: success() && github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.6.0](https://github.com/actions/setup-python/releases/tag/v4.6.0)** on 2023-04-20T12:36:13Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.8.6](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.6)** on 2023-05-02T21:18:12Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2)** on 2023-04-13T12:49:40Z
* **[xarray-contrib/ci-trigger](https://github.com/xarray-contrib/ci-trigger)** published a new release **[v1.2](https://github.com/xarray-contrib/ci-trigger/releases/tag/v1.2)** on 2022-10-25T10:18:56Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.2](https://github.com/actions/upload-artifact/releases/tag/v3.1.2)** on 2023-01-06T14:29:05Z
* **[conda-incubator/setup-miniconda](https://github.com/conda-incubator/setup-miniconda)** published a new release **[v2.2.0](https://github.com/conda-incubator/setup-miniconda/releases/tag/v2.2.0)** on 2022-11-12T00:24:01Z
* **[julia-actions/setup-julia](https://github.com/julia-actions/setup-julia)** published a new release **[v1.9.2](https://github.com/julia-actions/setup-julia/releases/tag/v1.9.2)** on 2023-02-09T23:02:51Z
