### PR TITLE
restrict julia version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python
-  - julia
+  - julia<1.9.0
   - pyjulia
   - matplotlib-base
   - numpy


### PR DESCRIPTION
might be a temporary fix for #216 until we know why newer versions of Julia fail.