### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,7 +131,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup python
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: '3.11'
       - name: Set up Julia

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3.5.3
 
     - name: Set up Python
-      uses: actions/setup-python@v4.6.1
+      uses: actions/setup-python@v4.7.0
       with:
         python-version: "3.10"
 
@@ -45,7 +45,7 @@ jobs:
 
     - name: Publish a Python distribution to PyPI
       if: success() && github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@v1.8.6
+      uses: pypa/gh-action-pypi-publish@v1.8.8
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.8.8](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.8)** on 2023-07-12T01:05:05Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.7.0](https://github.com/actions/setup-python/releases/tag/v4.7.0)** on 2023-07-13T14:05:58Z
