### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # We need the full repo to avoid this issue
       # https://github.com/actions/checkout/issues/23
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
           cp benchmarks.log .asv/results/
         working-directory: ${{ env.ASV_DIR }}
 
-      - uses: actions/upload-artifact@v3.1.2
+      - uses: actions/upload-artifact@v3.1.3
         if: always()
         with:
           name: asv-benchmark-results-${{ runner.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       triggered: '${{ steps.detect-trigger.outputs.trigger-found }}'
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 2
       - uses: xarray-contrib/ci-trigger@v1.2
@@ -29,7 +29,7 @@ jobs:
       run:
         shell: 'bash -l {0}'
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
       - name: Set up conda
@@ -59,7 +59,7 @@ jobs:
       run:
         shell: 'bash -l {0}'
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
       - uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           channels: conda-forge
@@ -89,7 +89,7 @@ jobs:
       run:
         shell: 'bash -l {0}'
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
@@ -127,7 +127,7 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
       - name: Setup python

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ jobs:
   packages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.0.0
 
     - name: Set up Python
       uses: actions/setup-python@v4.7.0

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)** on 2023-09-04T12:22:57Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.3](https://github.com/actions/upload-artifact/releases/tag/v3.1.3)** on 2023-09-06T19:16:46Z
