### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # We need the full repo to avoid this issue
       # https://github.com/actions/checkout/issues/23
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,10 @@ jobs:
     outputs:
       triggered: '${{ steps.detect-trigger.outputs.trigger-found }}'
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 2
-      - uses: xarray-contrib/ci-trigger@v1.2
+      - uses: xarray-contrib/ci-trigger@v1.2.1
         id: detect-trigger
         with:
           keyword: '[skip-ci]'
@@ -29,7 +29,7 @@ jobs:
       run:
         shell: 'bash -l {0}'
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 0
       - name: Set up conda
@@ -59,7 +59,7 @@ jobs:
       run:
         shell: 'bash -l {0}'
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
       - uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           channels: conda-forge
@@ -89,7 +89,7 @@ jobs:
       run:
         shell: 'bash -l {0}'
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
@@ -130,7 +130,7 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 0
       - name: Setup python

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ jobs:
   packages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.0.0
+    - uses: actions/checkout@v4.1.0
 
     - name: Set up Python
       uses: actions/setup-python@v4.7.0

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[xarray-contrib/ci-trigger](https://github.com/xarray-contrib/ci-trigger)** published a new release **[v1.2.1](https://github.com/xarray-contrib/ci-trigger/releases/tag/v1.2.1)** on 2023-09-20T07:36:44Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.0](https://github.com/actions/checkout/releases/tag/v4.1.0)** on 2023-09-22T17:42:49Z
