### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3.0.1
         with:
           # installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
           installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3.0.1
         with:
           auto-update-conda: false
           channels: conda-forge
@@ -60,7 +60,7 @@ jobs:
         shell: 'bash -l {0}'
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: conda-incubator/setup-miniconda@v2.2.0
+      - uses: conda-incubator/setup-miniconda@v3.0.1
         with:
           channels: conda-forge
           miniforge-variant: Mambaforge
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3.0.1
         with:
           auto-update-conda: false
           channels: conda-forge
@@ -134,11 +134,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup python
-        uses: actions/setup-python@v4.7.1
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: '3.11'
       - name: Set up Julia
-        uses: julia-actions/setup-julia@v1.9.2
+        uses: julia-actions/setup-julia@v1.9.4
         with:
           version: 1.7.1
       - name: Install dependencies

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4.1.1
 
     - name: Set up Python
-      uses: actions/setup-python@v4.7.1
+      uses: actions/setup-python@v5.0.0
       with:
         python-version: "3.10"
 
@@ -45,7 +45,7 @@ jobs:
 
     - name: Publish a Python distribution to PyPI
       if: success() && github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@v1.8.10
+      uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.0.0](https://github.com/actions/setup-python/releases/tag/v5.0.0)** on 2023-12-06T10:59:28Z
* **[julia-actions/setup-julia](https://github.com/julia-actions/setup-julia)** published a new release **[v1.9.4](https://github.com/julia-actions/setup-julia/releases/tag/v1.9.4)** on 2023-11-21T17:23:48Z
* **[conda-incubator/setup-miniconda](https://github.com/conda-incubator/setup-miniconda)** published a new release **[v3.0.1](https://github.com/conda-incubator/setup-miniconda/releases/tag/v3.0.1)** on 2023-11-29T18:51:45Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.8.11](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.11)** on 2023-11-29T02:41:33Z
