### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Set up Julia
-        uses: julia-actions/setup-julia@v1.9.4
+        uses: julia-actions/setup-julia@v1.9.5
         with:
           version: 1.7.1
       - name: Install dependencies


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[julia-actions/setup-julia](https://github.com/julia-actions/setup-julia)** published a new release **[v1.9.5](https://github.com/julia-actions/setup-julia/releases/tag/v1.9.5)** on 2024-01-05T18:36:18Z
