### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -74,7 +74,7 @@ jobs:
           cp benchmarks.log .asv/results/
         working-directory: ${{ env.ASV_DIR }}
 
-      - uses: actions/upload-artifact@v4.2.0
+      - uses: actions/upload-artifact@v4.3.0
         if: always()
         with:
           name: asv-benchmark-results-${{ runner.os }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.0](https://github.com/actions/upload-artifact/releases/tag/v4.3.0)** on 2024-01-23T17:40:41Z
