### PR TITLE
Fix pytest lazy fixture

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,6 @@ dependencies:
   - sphinx-book-theme
   - myst-nb
   - numcodecs>=0.10.0
-  - pytest-lazy-fixture
   - pip
   - pip:
     - -e .

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("CHANGELOG.rst") as history_file:
 with open("requirements.txt") as f:
     requirements = f.read().strip().split("\n")
 
-test_requirements = ["pytest", "pytest-lazy-fixture", "pooch", "netcdf4", "dask"]
+test_requirements = ["pytest", "pooch", "netcdf4", "dask"]
 
 extras_require = {
     "viz": ["matplotlib", "cmcrameri"],

--- a/tests/test_bitinformation_pipeline.py
+++ b/tests/test_bitinformation_pipeline.py
@@ -9,17 +9,18 @@ import xbitinfo as xb
 @pytest.mark.parametrize(
     "ds,dim,axis",
     [
-        (pytest.lazy_fixture("ugrid_demo"), None, -1),
-        (pytest.lazy_fixture("icon_grid_demo"), "ncells", None),
-        (pytest.lazy_fixture("air_temperature"), "lon", None),
-        (pytest.lazy_fixture("rasm"), "x", None),
-        (pytest.lazy_fixture("ROMS_example"), "eta_rho", None),
-        (pytest.lazy_fixture("era52mt"), "time", None),
-        (pytest.lazy_fixture("eraint_uvz"), "longitude", None),
+        ("ugrid_demo", None, -1),
+        ("icon_grid_demo", "ncells", None),
+        ("air_temperature", "lon", None),
+        ("rasm", "x", None),
+        ("ROMS_example", "eta_rho", None),
+        ("era52mt", "time", None),
+        ("eraint_uvz", "longitude", None),
     ],
 )
-def test_full(ds, dim, axis):
+def test_full(ds, dim, axis, request):
     """Test xbitinfo end to end."""
+    ds =  request.getfixturevalue(ds)
     # xbitinfo
     bitinfo = xb.get_bitinformation(ds, dim=dim, axis=axis)
     keepbits = xb.get_keepbits(bitinfo)

--- a/tests/test_bitinformation_pipeline.py
+++ b/tests/test_bitinformation_pipeline.py
@@ -20,7 +20,7 @@ import xbitinfo as xb
 )
 def test_full(ds, dim, axis, request):
     """Test xbitinfo end to end."""
-    ds =  request.getfixturevalue(ds)
+    ds = request.getfixturevalue(ds)
     # xbitinfo
     bitinfo = xb.get_bitinformation(ds, dim=dim, axis=axis)
     keepbits = xb.get_keepbits(bitinfo)

--- a/tests/test_get_bitinformation.py
+++ b/tests/test_get_bitinformation.py
@@ -226,17 +226,18 @@ def test_get_bitinformation_keep_attrs(rasm):
 @pytest.mark.parametrize(
     "ds,dim,axis",
     [
-        (pytest.lazy_fixture("ugrid_demo"), None, -1),
-        (pytest.lazy_fixture("icon_grid_demo"), "ncells", None),
-        (pytest.lazy_fixture("air_temperature"), "lon", None),
-        (pytest.lazy_fixture("rasm"), "x", None),
-        (pytest.lazy_fixture("ROMS_example"), "eta_rho", None),
-        (pytest.lazy_fixture("era52mt"), "time", None),
-        (pytest.lazy_fixture("eraint_uvz"), "longitude", None),
+        ("ugrid_demo", None, -1),
+        ("icon_grid_demo", "ncells", None),
+        ("air_temperature", "lon", None),
+        ("rasm", "x", None),
+        ("ROMS_example", "eta_rho", None),
+        ("era52mt", "time", None),
+        ("eraint_uvz", "longitude", None),
     ],
 )
-def test_implementations_agree(ds, dim, axis):
+def test_implementations_agree(ds, dim, axis, request):
     """Test whether the python and julia implementation retrieve the same results"""
+    ds =  request.getfixturevalue(ds)
     bi_python = xb.get_bitinformation(
         ds,
         dim=dim,

--- a/tests/test_get_bitinformation.py
+++ b/tests/test_get_bitinformation.py
@@ -237,7 +237,7 @@ def test_get_bitinformation_keep_attrs(rasm):
 )
 def test_implementations_agree(ds, dim, axis, request):
     """Test whether the python and julia implementation retrieve the same results"""
-    ds =  request.getfixturevalue(ds)
+    ds = request.getfixturevalue(ds)
     bi_python = xb.get_bitinformation(
         ds,
         dim=dim,


### PR DESCRIPTION
pytest_lazy_fixture causes issues with pytest==8.0.0.

This implements the workaround mentioned in https://github.com/TvoroG/pytest-lazy-fixture/issues/65 as pytest_lazy_fixture currently does not seem to be maintained.