### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3.0.1
+        uses: conda-incubator/setup-miniconda@v3.0.2
         with:
           # installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
           installer-url: https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
@@ -74,7 +74,7 @@ jobs:
           cp benchmarks.log .asv/results/
         working-directory: ${{ env.ASV_DIR }}
 
-      - uses: actions/upload-artifact@v4.3.0
+      - uses: actions/upload-artifact@v4.3.1
         if: always()
         with:
           name: asv-benchmark-results-${{ runner.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v3.0.1
+        uses: conda-incubator/setup-miniconda@v3.0.2
         with:
           auto-update-conda: false
           channels: conda-forge
@@ -60,7 +60,7 @@ jobs:
         shell: 'bash -l {0}'
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: conda-incubator/setup-miniconda@v3.0.1
+      - uses: conda-incubator/setup-miniconda@v3.0.2
         with:
           channels: conda-forge
           miniforge-variant: Mambaforge
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v3.0.1
+        uses: conda-incubator/setup-miniconda@v3.0.2
         with:
           auto-update-conda: false
           channels: conda-forge
@@ -138,7 +138,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Set up Julia
-        uses: julia-actions/setup-julia@v1.9.5
+        uses: julia-actions/setup-julia@v1.9.6
         with:
           version: 1.7.1
       - name: Install dependencies


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.1](https://github.com/actions/upload-artifact/releases/tag/v4.3.1)** on 2024-02-05T21:40:25Z
