### PR TITLE
[MNT]: Add ruff as the linting tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@ ci:
     autoupdate_schedule: quarterly
 
 
-# https://pre-commit.com/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -12,52 +11,21 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: mixed-line-ending
-    # This wants to go before isort & flake8
-  - repo: https://github.com/PyCQA/autoflake
-    rev: "v2.2.1"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.2
     hooks:
-      - id: autoflake # isort should run before black as black sometimes tweaks the isort output
-        args: ["--in-place", "--ignore-init-module-imports"]
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - "--py38-plus"
-  # https://github.com/python/black#version-control-integration
+      # run the linter
+      - id: ruff
+        args: [--fix, --ignore-noqa]
+
   - repo: https://github.com/psf/black
     rev: 23.12.1
     hooks:
       - id: black
       - id: black-jupyter
+
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
     hooks:
       - id: blackdoc
         exclude: docs/index.rst
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
-    hooks:
-      - id: mypy
-        exclude: "properties|asv_bench"
-        # This is slow and so we take it out of the fast-path; requires passing
-        # `--hook-stage manual` to pre-commit
-        stages: [manual]
-        additional_dependencies: [
-            # Type stubs
-            types-python-dateutil,
-            types-pkg_resources,
-            types-PyYAML,
-            types-pytz,
-            typing-extensions,
-            numpy,
-          ]

--- a/.ruffconfig
+++ b/.ruffconfig
@@ -1,6 +1,0 @@
-[lint]
-ignore = E203,E266,E501,W503,F403,F401
-max-line-length = 89
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-exclude = docs

--- a/.ruffconfig
+++ b/.ruffconfig
@@ -1,5 +1,5 @@
-[flake8]
-ignore = E203, E266, E501, W503, F403, F401
+[lint]
+ignore = E203,E266,E501,W503,F403,F401
 max-line-length = 89
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,110 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "pip"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest]
+addopts = "--ignore=setup.py"
+
+[tool.pytest.ini_options]
+norecursedirs = [
+    ".git",
+    ".github",
+    "docs",
+]
+
+[tool.ruff]
+line-length = 120
+target-version = "py38"
+exclude = [".git", "asv_bench", "docs", "conftest.py"]
+
+
+[tool.ruff.lint]
+select = [
+    # https://pypi.org/project/pycodestyle
+    "E",
+    "W",
+    # https://pypi.org/project/pyflakes
+    "F",
+    # https://pypi.org/project/flake8-bandit
+    "S",
+    # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "UP",
+    "I002",    # Missing required imports
+    "UP008",   # Super calls with redundant arguments passed.
+    "G010",    # Deprecated log warn.
+    "PLR1722", # Use sys.exit() instead of exit() and quit().
+    "PT014",   # pytest-duplicate-parametrize-test-cases.
+    "PT006",   # Checks for the type of parameter names passed to pytest.mark.parametrize.
+    "PT007",   # Checks for the type of parameter values passed to pytest.mark.parametrize.
+    "PT018",   # Checks for assertions that combine multiple independent conditions.
+]
+
+extend-select = [
+    "I",      # isort
+    "C4",     # https://pypi.org/project/flake8-comprehensions
+]
+
+ignore = [
+    "S101",  # Use of `assert` detected
+    "E203", # Whitespace-before-punctuation.
+    "E402", # Module-import-not-at-top-of-file.
+    "E731", # Do not assign a lambda expression, use a def.
+    "D100", # Missing docstring in public module.
+    "D101", # Missing docstring in public class.
+    "D102", # Missing docstring in public method.
+    "D103", # Missing docstring in public function.
+    "D104", # Missing docstring in public package.
+    "D105", # Missing docstring in magic method.
+    "D106", # Missing docstring in public nested class.
+    "D107", # Missing docstring in `__init__`.
+    "RET504", # Unnecessary variable assignment before `return` statement.
+    "S101", # Use of `assert` detected.
+    "S108",
+    "D203", # 1 blank line required before class docstring.
+    "D205", # 1 blank line required between summary line and description.
+    "D212", # Multi-line docstring summary should start at the first line.
+    "D213", # Multi-line docstring summary should start at the second line.
+    "D209", # Multi-line docstring closing quotes should be on a separate line.
+    "D400", # First line should end with a period.
+    "D413", # Missing blank line after last section of docstrings.
+    "D401", # First line of docstring should be in imperative mood.
+    "D415", # First line should end with a period, question mark, or exclamation point.
+    "D416", # Section name should end with a colon ("Attributes").
+    "D417", # Missing argument description in the docstring for argument "X".
+    "RUF100", # https://docs.astral.sh/ruff/rules/unused-noqa/
+    "C408",
+    "SIM118",
+    "RET506",
+    "TRY004",
+    "RET505",
+    "RET507",
+    "SIM108",
+    "SIM102",
+    "E501", # line too long
+    "E266",
+    "F403",
+    "F401",
+    "F841",
+    "RET",
+    "SIM",
+    "PT",
+]
+ignore-init-module-imports = true
+
+[tool.ruff.lint.per-file-ignores]
+
+"setup.py" = ["S101"]
+"**/__init__.py" = ["F401", "F403", "F405", "F811", "F821", "E501", "SIM102"]
+"tests/**" = [
+    "S605",  # Starting a process with a shell: seems safe, but may be changed in the future; consider rewriting without `shell`
+    "S607",  # Starting a process with a partial executable path
+    "RET504",  # todo:Unnecessary variable assignment before `return` statement
+    "PT004",  # Fixture `tmpdir_unittest_fixture` does not return anything, add leading underscore
+    "PT011",  # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
+    "PT012",  # `pytest.raises()` block should contain a single simple statement
+    "PT019",  # Fixture `_` without value is injected as parameter, use `@pytest.mark.usefixtures` instead
+    "PT006" # Checks for the type of parameter names passed to pytest.mark.parametrize.
+]
+
+[tool.blackdoc]
+exclude = "docs/index.rst"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-universal = 1
-
-[tool:pytest]
-addopts = --ignore=setup.py


### PR DESCRIPTION
This PR adds ruff as a linting tool and removes others like `flake8` and `black`

Given that `mypy` is usually too slow. It would be better  to run it in a separate CI job (if we choose to run it again in CI).

Added `pyproject.toml` and merged `setup.cfg` into it.

fixes #270 

Thanks