### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Set up Julia
-        uses: julia-actions/setup-julia@v1.9.6
+        uses: julia-actions/setup-julia@v2.0.0
         with:
           version: 1.7.1
       - name: Install dependencies


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[julia-actions/setup-julia](https://github.com/julia-actions/setup-julia)** published a new release **[v2.0.0](https://github.com/julia-actions/setup-julia/releases/tag/v2.0.0)** on 2024-04-01T15:40:00Z
