### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 2
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v2.6.1
         with:
           version: '1.10'
       - uses: xarray-contrib/ci-trigger@v1.2.1
@@ -35,11 +35,11 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v2.6.1
         with:
           version: '1.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v5.4.1
       - name: Run tests
         run: uv run --group test pytest tests
   doctest:
@@ -52,11 +52,11 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v2.6.1
         with:
           version: '1.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v5.4.1
       - name: Run doctests
         run: |
           uv run --group test python -m pytest --doctest-modules xbitinfo --ignore xbitinfo/tests
@@ -70,11 +70,11 @@ jobs:
         shell: 'bash -l {0}'
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v2.6.1
         with:
           version: '1.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v5.4.1
       - name: Test notebooks
         run: >
           uv run --group docs python -m ipykernel install --user --name bitinfo-docs
@@ -106,7 +106,7 @@ jobs:
         with:
           version: '1.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v5.4.1
       - name: Smoketest
         run: |
           uv run python -c "import xbitinfo"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[julia-actions/setup-julia](https://github.com/julia-actions/setup-julia)** published a new release **[v2.6.1](https://github.com/julia-actions/setup-julia/releases/tag/v2.6.1)** on 2024-11-18T15:37:17Z
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v5.4.1](https://github.com/astral-sh/setup-uv/releases/tag/v5.4.1)** on 2025-03-30T16:30:01Z
