### PR TITLE
Allow workflow_dispatch trigger for CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
   detect-ci-trigger:
     name: detect ci trigger
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     outputs:
       triggered: '${{ steps.detect-trigger.outputs.trigger-found }}'
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ unreleased
 * Limit numpy to <2.4.0 to temporarily fix some incompatibilities (:pr:`334`) `Hauke Schulz`_.
 * Add dependency listing to CI actions to see version changes (:pr:`334`) `Hauke Schulz`_.
 * Fix contributing guide to use uv instead of conda (:pr:`336`) `Olivier Bonte`_.
+* Allow manual triggering of all CI jobs (:pr:`337`) `Hauke Schulz`_.
 * Fix CI test with recent eccodes versions (:pr:`338`) `Hauke Schulz`_.
 
 0.0.6 (2025-11-20)


### PR DESCRIPTION
This PR adds the capability to trigger all CI jobs also manually.